### PR TITLE
Switch exports to module.exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ const getApp = async () => {
 
 const handler = lambdaRequestHandler.deferred(getApp);
 
-exports = { handler }
+module.exports = { handler }
 ```
 
 If the above file in your Lambda source was called `index.ts`, compiled to `index.js` then the name of the handler in the Lambda configuration is `index.handler`


### PR DESCRIPTION
There’s [a](https://blog.tableflip.io/the-difference-between-module-exports-and-exports/) [few](https://stackoverflow.com/questions/16383795/difference-between-module-exports-and-exports-in-the-commonjs-module-system) [weird](https://stackoverflow.com/questions/7137397/module-exports-vs-exports-in-node-js) [differences](https://www.sitepoint.com/understanding-module-exports-exports-node-js/) between module.exports and exports.  By using `module.exports`, I am able to fix my `Error: Cannot find module` error.  All said and done, I’m glad I can deploy nest.js with claudia.js 😄 

Funny enough, the [Nestjs example](https://github.com/janaz/lambda-request-handler/blame/master/README.md#L177) is the only one that needs fixing 😂